### PR TITLE
Add wheezy{-pu,-security} for LTS

### DIFF
--- a/architectures/amd64
+++ b/architectures/amd64
@@ -15,10 +15,13 @@ mapper: {'sid': 'unstable',
          'buster': 'testing',
          'stretch': 'stable',
          'jessie': 'oldstable',
+         'wheezy': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
+         'oldoldstable-proposed-updates': 'oldoldstable',
          'stretch-security': 'stable',
          'jessie-security': 'oldstable',
+         'wheezy-security': 'oldoldstable',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}
 

--- a/architectures/armel
+++ b/architectures/armel
@@ -15,10 +15,13 @@ mapper: {'sid': 'unstable',
          'buster': 'testing',
          'stretch': 'stable',
          'jessie': 'oldstable',
+         'wheezy': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
+         'oldoldstable-proposed-updates': 'oldoldstable',
          'stretch-security': 'stable',
          'jessie-security': 'oldstable',
+         'wheezy-security': 'oldoldstable',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}
 

--- a/architectures/armhf
+++ b/architectures/armhf
@@ -15,10 +15,13 @@ mapper: {'sid': 'unstable',
          'buster': 'testing',
          'stretch': 'stable',
          'jessie': 'oldstable',
+         'wheezy': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
+         'oldoldstable-proposed-updates': 'oldoldstable',
          'stretch-security': 'stable',
          'jessie-security': 'oldstable',
+         'wheezy-security': 'oldoldstable',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}
 

--- a/architectures/i386
+++ b/architectures/i386
@@ -15,10 +15,13 @@ mapper: {'sid': 'unstable',
          'buster': 'testing',
          'stretch': 'stable',
          'jessie': 'oldstable',
+         'wheezy': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
+         'oldoldstable-proposed-updates': 'oldoldstable',
          'stretch-security': 'stable',
          'jessie-security': 'oldstable',
+         'wheezy-security': 'oldoldstable',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}
 

--- a/distributions/amd64
+++ b/distributions/amd64
@@ -32,6 +32,13 @@ components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
 
+[oldoldstable]
+suite: oldoldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldoldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldoldstable-updates main contrib non-free
+
 [stretch-backports]
 suite: stretch
 mirror: http://deb.debian.org/debian

--- a/distributions/armel
+++ b/distributions/armel
@@ -32,6 +32,13 @@ components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
 
+[oldoldstable]
+suite: oldoldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldoldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldoldstable-updates main contrib non-free
+
 [stretch-backports]
 suite: stretch
 mirror: http://deb.debian.org/debian

--- a/distributions/armhf
+++ b/distributions/armhf
@@ -32,6 +32,13 @@ components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
 
+[oldoldstable]
+suite: oldoldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldoldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldoldstable-updates main contrib non-free
+
 [stretch-backports]
 suite: stretch
 mirror: http://deb.debian.org/debian

--- a/distributions/i386
+++ b/distributions/i386
@@ -32,6 +32,13 @@ components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
 
+[oldoldstable]
+suite: oldoldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldoldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldoldstable-updates main contrib non-free
+
 [stretch-backports]
 suite: stretch
 mirror: http://deb.debian.org/debian


### PR DESCRIPTION
This PR aims to add the availability of wheezy instance on relevant architectures (those officially supported by the LTS Team) for test-building packages targetting that release.