### PR TITLE
fix bullseye/stable build and add bullseye-backports

### DIFF
--- a/architectures/amd64
+++ b/architectures/amd64
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/amd64
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/arm64
+++ b/architectures/arm64
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/arm64
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/armel
+++ b/architectures/armel
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/armel
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/armhf
+++ b/architectures/armhf
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/armhf
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/i386
+++ b/architectures/i386
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/i386
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/mips
+++ b/architectures/mips
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/mips
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/mips64el
+++ b/architectures/mips64el
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/mips64el
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/mipsel
+++ b/architectures/mipsel
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/mipsel
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/powerpc
+++ b/architectures/powerpc
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/powerpc
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/ppc64el
+++ b/architectures/ppc64el
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/ppc64el
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/architectures/s390x
+++ b/architectures/s390x
@@ -14,16 +14,16 @@ loglevel: info
 list: /home/debomatic/config/distributions/s390x
 blacklist:
 mapper: {'sid': 'unstable',
-         'bullseye': 'testing',
-         'buster': 'stable',
-         'stretch': 'oldstable',
-         'jessie': 'oldoldstable',
+         'bookworm': 'testing',
+         'bullseye': 'stable',
+         'buster': 'oldstable',
+         'stretch': 'oldoldstable',
          'proposed-updates': 'stable',
          'oldstable-proposed-updates': 'oldstable',
          'oldoldstable-proposed-updates': 'oldoldstable',
-         'buster-security': 'stable',
-         'stretch-security': 'oldstable',
-         'jessie-security': 'oldoldstable',
+         'bullseye-security': 'stable',
+         'buster-security': 'oldstable',
+         'stretch-security': 'oldoldstable',
          'buster-backports-sloppy': 'buster-backports',
          'stretch-backports-sloppy': 'stretch-backports',
          'jessie-backports-sloppy': 'jessie-backports'}

--- a/distributions/amd64
+++ b/distributions/amd64
@@ -23,7 +23,7 @@ extramirrors: deb http://debomatic-amd64.debian.net/debomatic/testing testing ma
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
 
 [oldstable]
@@ -32,6 +32,14 @@ mirror: http://deb.debian.org/debian
 components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/arm64
+++ b/distributions/arm64
@@ -23,8 +23,23 @@ extramirrors: deb http://debomatic-arm64.debian.net/debomatic/testing testing ma
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
+
+[oldstable]
+suite: oldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/armel
+++ b/distributions/armel
@@ -23,7 +23,7 @@ extramirrors: deb http://debomatic-armel.debian.net/debomatic/testing testing ma
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
 
 [oldstable]
@@ -32,6 +32,14 @@ mirror: http://deb.debian.org/debian
 components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/armhf
+++ b/distributions/armhf
@@ -23,7 +23,7 @@ extramirrors: deb http://debomatic-armhf.debian.net/debomatic/testing testing ma
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
 
 [oldstable]
@@ -32,6 +32,14 @@ mirror: http://deb.debian.org/debian
 components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/i386
+++ b/distributions/i386
@@ -23,7 +23,7 @@ extramirrors: deb http://debomatic-i386.debian.net/debomatic/testing testing mai
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
 
 [oldstable]
@@ -32,6 +32,14 @@ mirror: http://deb.debian.org/debian
 components: main contrib non-free
 extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
               deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/mips
+++ b/distributions/mips
@@ -23,8 +23,23 @@ extramirrors: deb http://debomatic-mips.debian.net/debomatic/testing testing mai
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
+
+[oldstable]
+suite: oldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/mips64el
+++ b/distributions/mips64el
@@ -23,8 +23,23 @@ extramirrors: deb http://debomatic-mips64el.debian.net/debomatic/testing testing
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
+
+[oldstable]
+suite: oldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/mipsel
+++ b/distributions/mipsel
@@ -23,8 +23,23 @@ extramirrors: deb http://debomatic-mipsel.debian.net/debomatic/testing testing m
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
+
+[oldstable]
+suite: oldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/ppc64el
+++ b/distributions/ppc64el
@@ -23,8 +23,23 @@ extramirrors: deb http://debomatic-ppc64el.debian.net/debomatic/testing testing 
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
+
+[oldstable]
+suite: oldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster

--- a/distributions/s390x
+++ b/distributions/s390x
@@ -23,8 +23,23 @@ extramirrors: deb http://debomatic-s390x.debian.net/debomatic/testing testing ma
 suite: stable
 mirror: http://deb.debian.org/debian
 components: main contrib non-free
-extramirrors: deb http://deb.debian.org/debian-security stable/updates main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ stable-security main contrib non-free
               deb http://deb.debian.org/debian stable-updates main contrib non-free
+
+[oldstable]
+suite: oldstable
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security oldstable/updates main contrib non-free
+              deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+
+[bullseye-backports]
+suite: bullseye
+mirror: http://deb.debian.org/debian
+components: main contrib non-free
+extramirrors: deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free
+              deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+              deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 
 [buster-backports]
 suite: buster


### PR DESCRIPTION
@dktrkranz actually bullseye/stable build fails and bullseye-backports don't start, I tested changes on local debomatic and built successfull on both bullseye and bullseye-backports, I prepared this PR to make faster to save you time, can you update the debomatic-*.debian.net please?